### PR TITLE
Added bench/roulette.lua

### DIFF
--- a/bench/roulette.lua
+++ b/bench/roulette.lua
@@ -1,0 +1,20 @@
+-- Russian Roulette simulator
+-- This benchmark includes randomness from an external source that can
+-- produce non-deterministic performance.
+-- See https://github.com/LuaJIT/LuaJIT/issues/218
+
+math.randomseed(os.time())
+
+local population = 100e6
+local live = 0
+local die  = 0
+
+for i = 1, population do
+   if math.random(6) == 6 then
+      die = die + 1
+   else
+      live = live + 1
+   end
+end
+
+print(("Survived %d/%d (%.3f%%)"):format(live, population, live*100/(live+die)))

--- a/bench/roulette.lua
+++ b/bench/roulette.lua
@@ -3,7 +3,8 @@
 -- produce non-deterministic performance.
 -- See https://github.com/LuaJIT/LuaJIT/issues/218
 
-math.randomseed(os.time())
+-- (Let the test harness determine the random seed)
+-- math.randomseed(os.time())
 
 local population = 100e6
 local live = 0


### PR DESCRIPTION
This benchmark exhibits non-deterministic performance. See LuaJIT/LuaJIT#218.

I think that it is important to include tests that can demonstrate non-deterministic performance. The challenge I see is to make performance as consistent as possible while including as much entropy as possible on the inputs.

Paraphrasing Dijkstra:

> I used to think that benchmarks have to be deterministic. Now I realize that deterministic benchmarks are only a special case of non-deterministic benchmarks, and not a particularly interesting one at that.

Requires a test harness that can account for variation. More on that to follow...
